### PR TITLE
Add NihdiCompetenceCode

### DIFF
--- a/src/main/openapi/healthcare/v1/healthcare-v1.yaml
+++ b/src/main/openapi/healthcare/v1/healthcare-v1.yaml
@@ -13,3 +13,8 @@ components:
       description: Identification number attributed by NIHDI (RIZIV-INAMI) to health care providers in Belgium within the framework of the compulsory health insurance
       type: string
       pattern: '^\d{8}$'
+    NihdiCompetenceCode:
+      description: Code assigned by NIHDI to identify the recognized profession of a healthcare provider
+      type: string
+      pattern: '^\d{3}$'
+      example: "003"


### PR DESCRIPTION
Aligned with new fedvoc entry added in https://github.com/belgif/fedvoc/issues/34
@VirginieHayot , could eHealth review this schema?

Once added, should be marked in FedVoc as "inOpenAPI"